### PR TITLE
Exercise User Ids, Fixed Summary Generation

### DIFF
--- a/node/src/controllers/cWorkout.js
+++ b/node/src/controllers/cWorkout.js
@@ -84,9 +84,10 @@ async function GetWorkout(req,res,next){
  */
 async function AddExercise(req,res,next){
     const {workout_id,motion_id} = res.locals.bodyData;
+    const user = res.locals.user;
     try{
         const motion = await Motion.findOne({_id:motion_id})
-        const addedExercise = (motion) ? new Exercise({motion: {motion: motion_id}}) : new Exercise({motion: {umotion: motion_id}}) ;
+        const addedExercise = (motion) ? new Exercise({motion: {motion: motion_id},user_id:user}) : new Exercise({motion: {umotion: motion_id}}) ;
         const newEx = await addedExercise.save();
         
         
@@ -132,6 +133,20 @@ async function RemoveExercise(req, res, next) {
         return next({message:e.message,code:500});
     }
 
+}
+
+
+async function GetExercise(req,res,next){
+    const {exercise_id} = res.locals.bodyData;
+    const user = res.locals.user;
+
+    try{
+        const found = await Exercise.findOne({_id:exercise_id,user_id:user}).populate({path: 'sets motion.motion motion.umotion'})
+        res.send({exercise:found, exercise_id:exercise_id})
+    }
+    catch(e){
+        next({code:500,message:e.message})
+    }
 }
 
 // add set to an exercise 
@@ -222,4 +237,4 @@ async function EditWorkoutName(req, res, next) {
 // maybe a finish exercise function which would flag the workout as completed so that new exercises arent added //
 
 
-module.exports = {EditWorkoutName:EditWorkoutName, GetWorkout:GetWorkout, ListMyWorkouts:ListMyWorkouts, CreateWorkout: CreateWorkout,  DeleteWorkout:DeleteWorkout, AddExercise:AddExercise, RemoveExercise:RemoveExercise, AddSet:AddSet , RemoveSet: RemoveSet}    
+module.exports = {GetExercise,EditWorkoutName:EditWorkoutName, GetWorkout:GetWorkout, ListMyWorkouts:ListMyWorkouts, CreateWorkout: CreateWorkout,  DeleteWorkout:DeleteWorkout, AddExercise:AddExercise, RemoveExercise:RemoveExercise, AddSet:AddSet , RemoveSet: RemoveSet}    

--- a/node/src/models/mWorkout.js
+++ b/node/src/models/mWorkout.js
@@ -103,7 +103,8 @@ const ExerciseSchema = new mongoose.Schema({
         motion: {type: mongoose.Schema.Types.ObjectId, ref: 'Motion' },
         umotion: {type: mongoose.Schema.Types.ObjectId, ref: 'UserMotion'}
     },
-    sets: [{type: mongoose.Schema.Types.ObjectId, ref: 'Set'}]
+    sets: [{type: mongoose.Schema.Types.ObjectId, ref: 'Set'}],
+    user_id: {type: mongoose.Schema.Types.ObjectId,ref:'Users'}
 
 })
 

--- a/node/src/routes/rWorkout.js
+++ b/node/src/routes/rWorkout.js
@@ -20,6 +20,7 @@ const REQUIRED_KEYS = {
     "/remSet": ["set_id", "exercise_id"],
     "/get": ["workout_id"],
     "/editName": ["workout_id", "name"],
+    "/getEx": ["exercise_id"]
 }
 
 WorkoutRouter.use(bodyParser.json());
@@ -63,6 +64,10 @@ WorkoutRouter.delete('/remEx', async(req, res, next) => {
 WorkoutRouter.post('/addEx', async(req,res,next) => {
     WorkoutControllers.AddExercise(req,res,next);
 })
+
+//Get a single exercises data
+WorkoutRouter.post('/getEx', WorkoutControllers.GetExercise);
+
 
 //add set to Exercise 
 WorkoutRouter.post('/addSet', async(req, res, next) => {

--- a/node/src/tests/rUser.test.js
+++ b/node/src/tests/rUser.test.js
@@ -80,15 +80,6 @@ describe('Summary Tests', ()=>{
         expect(res.status).toBe(416);
     })
 
-    it('Add a new Workout', async ()=> {
-        const response =  await request.post('/workout/add').set('authorization',token)
-
-        expect(response.status).toBe(200);
-        expect(response.body).toHaveProperty('created')
-        expect(response.body).toHaveProperty('workout_id')
-        expect(response.body.created).toBe(true);
-        workout_id = response.body.workout_id
-    })
 
     it('Valid summary generation', async () => {
         const time = Date.now()+1000000;

--- a/node/src/tests/rWorkout.test.js
+++ b/node/src/tests/rWorkout.test.js
@@ -133,6 +133,14 @@ describe('Exercise Actions', ()=>{
         
     })
 
+    it('Get the exercise', async()=>{
+        const res = await request.post('/workout/getEx').set('authorization',token).send({exercise_id:exercise_id})
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveProperty('exercise');
+        expect(res.body).toHaveProperty('exercise_id');
+        expect(res.body.exercise).toHaveProperty('sets')
+    })
+
     it('Remove a invalid exercise', async()=>{
         const res = await request.delete('/workout/remEx').set('authorization', token).send({workout_id:workout_id, exercise_id: 'notanid'})
 


### PR DESCRIPTION
**Headlines**
- Added in a field the Exercise schema to track the user id so that users can get/edit exercises independently of the workout if need be (to hopefully reduce request load on both sides [Hopefully should replace a larger request with a smaller one)
- There were some issues remaining in summary generation but they mostly seem fixed at this point